### PR TITLE
package.nix support for Go 1.13

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -7,6 +7,7 @@ let
   modSha256 = {
     "1.11" = "1zj90zvbn258sykl1kdh57y1y34vis0ygjjaicvs60m3v24ig2wf";
     "1.12" = "02ppjvaz5lkz0afwbcrf8xk986bs88dqzm0aphbkq0x9jdv7dhxr";
+    "1.13" = "02ppjvaz5lkz0afwbcrf8xk986bs88dqzm0aphbkq0x9jdv7dhxr";
   }.${goVersion} or (throw "Missing modSha256 for go version ${goVersion}");
 in
 


### PR DESCRIPTION
Turns out it yields the same modSha256 as Go 1.12