### PR TITLE
tasmota: implement compact encoding

### DIFF
--- a/emitters/tasmota/config.go
+++ b/emitters/tasmota/config.go
@@ -12,10 +12,11 @@ import (
 type Config struct {
 	types.Emitter `yaml:",inline"`
 	Topic         string
+	Compact       bool
 }
 
 func (cfg *Config) New(c mqtt.Client, logger *log.Logger) (emitters.Emitter, error) {
-	return NewTasmotaEmitter(c, logger, cfg.Topic), nil
+	return NewTasmotaEmitter(c, logger, cfg.Topic, cfg.Compact), nil
 }
 
 func (cfg *Config) Id() string {

--- a/emitters/tasmota/tasmota_test.go
+++ b/emitters/tasmota/tasmota_test.go
@@ -1,0 +1,25 @@
+package tasmota
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_compactEncoding(t *testing.T) {
+	encodingExamples := []struct {
+		input   []uint16
+		encoded string
+	}{
+		// Minimal example
+		{[]uint16{432, 0, 432, 0},
+			"+432-0Ab"},
+
+		// Example from the website
+		{[]uint16{8570, 4240, 550, 1580, 550, 510, 565, 1565, 565, 505, 565, 505},
+			"+8570-4240+550-1580C-510+565-1565F-505Fh"},
+	}
+
+	for _, example := range encodingExamples {
+		assert.Equal(t, example.encoded, compactEncoding(example.input))
+	}
+}


### PR DESCRIPTION
Corresponds to unreleased feature from Tasmota: [new compact IR encoding](https://tasmota.github.io/docs/IRSend-RAW-Encoding/#new-ir-raw-compact-encoding). I'll hold off merging until it's released upstream and this integration is tested with it.